### PR TITLE
require node <17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "sketch-module-web-view": "git://github.com/lucian/sketch-module-web-view.git#expose-close-handler"
       },
       "engines": {
+        "node": ">=16.0.0 <17.0.0",
+        "npm": ">=8.0.0 <9.0.0",
         "sketch": ">=49.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "url": "https://github.com/lucian/sketch-syntax-highlighter.git"
   },
   "engines": {
-    "sketch": ">=49.0"
+    "sketch": ">=49.0",
+    "node": ">=16.0.0 <17.0.0",
+    "npm": ">=8.0.0 <9.0.0"
   },
   "skpm": {
     "name": "sketch-syntax-highlighter",


### PR DESCRIPTION
plugin fails to build on node versions >16, added warning flag when running `npm run build` with incompatible node versions